### PR TITLE
Let ASGI server enforce deadlines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
         entrypoint: /bin/bash
     steps:
       - checkout
-      - run: sudo pip3 install grpcio-tools grpcio requests
+      - run: sudo pip3 install grpcio-tools
+      - run: sudo pip3 install .
       - run: |
           python3 -m grpc.tools.protoc \
             --proto_path=$(pwd) \
@@ -58,7 +59,8 @@ jobs:
         entrypoint: /bin/bash
     steps:
       - checkout
-      - run: sudo pip3 install grpcio-tools grpcio requests daphne
+      - run: sudo pip3 install grpcio-tools daphne
+      - run: sudo pip3 install .
       - run: |
           python3 -m grpc.tools.protoc \
             --proto_path="$(pwd)" \

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ EMAIL = "alexs@prol.etari.at"
 AUTHOR = "Alex Stapleton"
 REQUIRES_PYTHON = ">=3.7.0"
 
-REQUIRED = ["grpcio", "requests", "aiohttp"]
+REQUIRED = ["grpcio", "requests", "aiohttp", "async-timeout"]
 
 TESTS_REQUIRED = [
     "grpcio-tools",

--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -39,7 +39,7 @@ class grpcASGI(grpc.Server):
                         await self._do_grpc_request(rpc_method, context, receive, send)
                 except asyncio.TimeoutError:
                     context.code = grpc.StatusCode.DEADLINE_EXCEEDED
-                    context.details = "rpc timed out"
+                    context.details = "request timed out at the server"
                     await self._do_grpc_error(context, send)
 
             elif request_method == "OPTIONS":

--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -71,7 +71,7 @@ class grpcASGI(grpc.Server):
     def _create_context(self, scope):
         timeout = None
 
-        for header, value in scope['headers']:
+        for header, value in scope["headers"]:
             if header == b"grpc-timeout":
                 timeout = protocol.parse_timeout(value)
                 break

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -96,6 +96,9 @@ class Call:
         self._deserializer = deserializer
         self._response = None
 
+        if timeout is not None:
+            self._metadata['grpc-timeout'] = protocol.serialize_timeout(timeout)
+
     @classmethod
     def _raise_timeout(cls, exc):
         def decorator(func):
@@ -108,7 +111,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout} timeout",
+                            f"exceeded {self._timeout}s timeout",
                         )
 
             elif inspect.iscoroutinefunction(func):
@@ -119,7 +122,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout} timeout",
+                            f"exceeded {self._timeout}s timeout",
                         )
 
             elif inspect.isgeneratorfunction(func):
@@ -131,7 +134,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout} timeout",
+                            f"exceeded {self._timeout}s timeout",
                         )
 
             else:
@@ -142,7 +145,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout} timeout",
+                            f"exceeded {self._timeout}s timeout",
                         )
 
             return functools.wraps(func)(wrapper)

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -111,7 +111,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout}s timeout",
+                            "request timed out at the client",
                         )
 
             elif inspect.iscoroutinefunction(func):
@@ -122,7 +122,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout}s timeout",
+                            "request timed out at the client",
                         )
 
             elif inspect.isgeneratorfunction(func):
@@ -134,7 +134,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout}s timeout",
+                            "request timed out at the client",
                         )
 
             else:
@@ -145,7 +145,7 @@ class Call:
                     except exc:
                         raise protocol.WebRpcError(
                             grpc.StatusCode.DEADLINE_EXCEEDED,
-                            f"exceeded {self._timeout}s timeout",
+                            "request timed out at the client",
                         )
 
             return functools.wraps(func)(wrapper)

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -97,7 +97,7 @@ class Call:
         self._response = None
 
         if timeout is not None:
-            self._metadata['grpc-timeout'] = protocol.serialize_timeout(timeout)
+            self._metadata["grpc-timeout"] = protocol.serialize_timeout(timeout)
 
     @classmethod
     def _raise_timeout(cls, exc):

--- a/sonora/context.py
+++ b/sonora/context.py
@@ -1,10 +1,19 @@
+import time
+
 import grpc
 
 
 class gRPCContext(grpc.ServicerContext):
-    def __init__(self):
+    def __init__(self, timeout=None):
         self.code = grpc.StatusCode.OK
         self.details = None
+
+        self._timeout = timeout
+
+        if timeout is not None:
+            self._deadline = time.monotonic() + timeout
+        else:
+            self._deadline = None
 
     def set_code(self, code):
         self.code = code
@@ -28,6 +37,12 @@ class gRPCContext(grpc.ServicerContext):
         self.set_code(status)
 
         raise grpc.RpcError()
+
+    def time_remaining(self):
+        if self._deadline is not None:
+            return max(time.monotonic() - self._deadline, 0)
+        else:
+            return None
 
     def invocation_metadata(self):
         raise NotImplementedError()
@@ -57,7 +72,4 @@ class gRPCContext(grpc.ServicerContext):
         raise NotImplementedError()
 
     def is_active(self):
-        raise NotImplementedError()
-
-    def time_remaining(self):
         raise NotImplementedError()

--- a/sonora/protocol.py
+++ b/sonora/protocol.py
@@ -181,3 +181,43 @@ def raise_for_status(headers, trailers=None):
             metadata["grpc-message"] = unquote(metadata["grpc-message"])
 
         raise WebRpcError.from_metadata(metadata)
+
+
+_timeout_units = {
+    b"H": 3600.0,
+    b"M": 60.0,
+    b"S": 1.0,
+    b"m": 1 / 1000.0,
+    b"u": 1 / 1000000.0,
+    b"n": 1 / 1000000000.0,
+}
+
+
+def parse_timeout(value):
+    units = value[-1:]
+    coef = _timeout_units[units]
+    count = int(value[:-1])
+    return count * coef
+
+
+def serialize_timeout(seconds):
+    if seconds % 3600 == 0:
+        value = seconds
+        units = "H"
+    elif seconds % 60 == 0:
+        value = seconds
+        units = "M"
+    elif seconds % 1 == 0:
+        value = seconds
+        units = "S"
+    elif seconds >= 1 / 1000.0:
+        value = seconds * 1000
+        units = "m"
+    elif seconds >= 1 / 1000000.0:
+        value = seconds * 1000000
+        units = "u"
+    else:
+        value = seconds * 1000000000
+        units = "n"
+
+    return f"{int(value)}{units}"

--- a/sonora/wsgi.py
+++ b/sonora/wsgi.py
@@ -90,10 +90,18 @@ class grpcWSGI(grpc.Server):
         else:
             return stream.read(content_length or 5)
 
+    def _create_context(self, environ):
+        try:
+            timeout = protocol.parse_timeout(environ["HTTP_GRPC_TIMEOUT"])
+        except KeyError:
+            timeout = None
+
+        return gRPCContext(timeout)
+
     def _do_grpc_request(self, rpc_method, environ, start_response):
         request_data = self._read_request(environ)
 
-        context = gRPCContext()
+        context = self._create_context(environ)
 
         _, _, message = protocol.unrwap_message(request_data)
         request_proto = rpc_method.request_deserializer(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,16 +53,20 @@ def _wsgi_server(lock, port):
 def _asgi_application():
     class Greeter(helloworld_pb2_grpc.GreeterServicer):
         async def SayHello(self, request, context):
-            if request.name == "timeout":
+            if request.name == "server timeout":
                 await asyncio.sleep(100)
+            elif request.name == "client timeout":
+                time.sleep(100)
 
             return helloworld_pb2.HelloReply(
                 message=FORMAT_STRING.format(request=request)
             )
 
         async def SayHelloSlowly(self, request, context):
-            if request.name == "timeout":
+            if request.name == "server timeout":
                 await asyncio.sleep(100)
+            elif request.name == "client timeout":
+                time.sleep(100)
 
             message = FORMAT_STRING.format(request=request)
 

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -46,7 +46,7 @@ async def test_helloworld_sayhelloslowly_with_timeout(asgi_grpc_server):
                     await call.read()
 
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-        assert exc.value.details().startswith("exceeded")
+        assert exc.value.details() == "request timed out at the client"
 
 
 @pytest.mark.asyncio
@@ -60,4 +60,4 @@ async def test_helloworld_sayhello_timeout_async(asgi_grpc_server):
         with pytest.raises(grpc.RpcError) as exc:
             await stub.SayHello(request, timeout=0.0000001)
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-        assert exc.value.details().startswith("exceeded")
+        assert exc.value.details() == "request timed out at the client"

--- a/tests/test_asgi_helloworld.py
+++ b/tests/test_asgi_helloworld.py
@@ -70,11 +70,11 @@ async def test_helloworld_sayhello_timeout_async(asgi_grpc_server):
     ) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
 
-        request = helloworld_pb2.HelloRequest(name="timeout")
+        request = helloworld_pb2.HelloRequest(name="server timeout")
         with pytest.raises(grpc.RpcError) as exc:
-            await stub.SayHello(request, timeout=0.0000001)
+            await stub.SayHello(request, timeout=0.1)
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-
+        assert exc.value.details() == "rpc timed out"
 
 @pytest.mark.asyncio
 async def test_helloworld_sayhelloslowly_async(asgi_grpc_server):
@@ -98,14 +98,14 @@ async def test_helloworld_sayhelloslowly_timeout_async(asgi_grpc_server):
     ) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
 
-        request = helloworld_pb2.HelloRequest(name="timeout")
+        request = helloworld_pb2.HelloRequest(name="server timeout")
         response = stub.SayHelloSlowly(request, timeout=0.0000001)
 
         with pytest.raises(grpc.RpcError) as exc:
             async for r in response:
                 pass
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-
+        assert exc.value.details() == "rpc timed out"
 
 @pytest.mark.asyncio
 async def test_helloworld_abort_async(asgi_grpc_server):

--- a/tests/test_asgi_helloworld.py
+++ b/tests/test_asgi_helloworld.py
@@ -74,7 +74,7 @@ async def test_helloworld_sayhello_timeout_async(asgi_grpc_server):
         with pytest.raises(grpc.RpcError) as exc:
             await stub.SayHello(request, timeout=0.1)
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-        assert exc.value.details() == "rpc timed out"
+        assert exc.value.details() == "request timed out at the server"
 
 
 @pytest.mark.asyncio
@@ -106,7 +106,7 @@ async def test_helloworld_sayhelloslowly_timeout_async(asgi_grpc_server):
             async for r in response:
                 pass
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-        assert exc.value.details() == "rpc timed out"
+        assert exc.value.details() == "request timed out at the server"
 
 
 @pytest.mark.asyncio

--- a/tests/test_asgi_helloworld.py
+++ b/tests/test_asgi_helloworld.py
@@ -76,6 +76,7 @@ async def test_helloworld_sayhello_timeout_async(asgi_grpc_server):
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
         assert exc.value.details() == "rpc timed out"
 
+
 @pytest.mark.asyncio
 async def test_helloworld_sayhelloslowly_async(asgi_grpc_server):
     async with sonora.aio.insecure_web_channel(
@@ -106,6 +107,7 @@ async def test_helloworld_sayhelloslowly_timeout_async(asgi_grpc_server):
                 pass
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
         assert exc.value.details() == "rpc timed out"
+
 
 @pytest.mark.asyncio
 async def test_helloworld_abort_async(asgi_grpc_server):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -54,3 +54,8 @@ async def test_unwrapping_asgi():
         resp_messages.append(resp)
 
     assert resp_messages == messages
+
+
+def test_parse_timeout():
+    seconds = protocol.parse_timeout(b"100n")
+    assert seconds - 0.0000001 < 0.0000001


### PR DESCRIPTION
Solves #11 

Can't actually enforce the timeout in the WSGI middleware but `context.time_remaining` will do the right thing anyway so it can be passed on to to other things that can enforce it if desired.

The ASGI implementation will now self terminate requests that exceed the deadline as long as they wan't stuck in some sync code.