### PR TITLE
Benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - checkout
       - run: sudo pip install tox
+      - run: sudo apt-get install python3-dev libev-dev
       - run: tox -e py37
   test-py38:
     docker:
@@ -22,6 +23,7 @@ jobs:
     steps:
       - checkout
       - run: sudo pip install tox
+      - run: sudo apt-get install python3-dev libev-dev
       - run: tox -e py38
   black-py37:
     docker:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ TESTS_REQUIRED = [
     "requests",
     "daphne",
     "uvicorn",
+    "aiohttp[speedups]",
 ]
 
 EXTRAS = {"tests": TESTS_REQUIRED}

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ TESTS_REQUIRED = [
     "pytest",
     "pytest-mockservers",
     "pytest-asyncio",
+    "pytest-benchmark",
     "requests",
     "daphne",
 ]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TESTS_REQUIRED = [
     "pytest-asyncio",
     "pytest-benchmark",
     "requests",
-    "daphne",
+    "bjoern",
     "uvicorn",
     "aiohttp[speedups]",
 ]

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ TESTS_REQUIRED = [
     "pytest-benchmark",
     "requests",
     "daphne",
+    "uvicorn",
 ]
 
 EXTRAS = {"tests": TESTS_REQUIRED}

--- a/sonora/aio.py
+++ b/sonora/aio.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import aiohttp
 import grpc.experimental.aio
 
@@ -12,6 +13,9 @@ def insecure_web_channel(url):
 
 class WebChannel:
     def __init__(self, url):
+        if not url.startswith("http") and "://" not in url:
+            url = f"http://{url}"
+
         self._url = url
         self._session = aiohttp.ClientSession()
 

--- a/sonora/aio.py
+++ b/sonora/aio.py
@@ -35,10 +35,10 @@ class WebChannel:
         )
 
     def stream_unary(self, path, request_serializer, response_deserializer):
-        raise NotImplementedError()
+        return sonora.client.NotImplementedMulticallable()
 
     def stream_stream(self, path, request_serializer, response_deserializer):
-        raise NotImplementedError()
+        return sonora.client.NotImplementedMulticallable()
 
 
 class UnaryUnaryMulticallable(sonora.client.Multicallable):
@@ -133,7 +133,6 @@ class UnaryStreamCall(Call):
     @Call._raise_timeout(asyncio.TimeoutError)
     async def __aiter__(self):
         response = await self._get_response()
-
         async for trailers, _, message in protocol.unwrap_message_stream_async(
             response.content
         ):

--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -140,7 +140,7 @@ class grpcASGI(grpc.Server):
 
                     if receive_task.done():
                         message = receive_task.result()
-                        if message['type'] == 'http.disconnect':
+                        if message["type"] == "http.disconnect":
                             break
                         else:
                             receive_task = asyncio.create_task(receive())

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -14,6 +14,9 @@ def insecure_web_channel(url):
 
 class WebChannel:
     def __init__(self, url):
+        if not url.startswith("http") and "://" not in url:
+            url = f"http://{url}"
+
         self._url = url
         self._session = requests.Session()
 

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -34,10 +34,10 @@ class WebChannel:
         )
 
     def stream_unary(self, path, request_serializer, response_deserializer):
-        raise NotImplementedError()
+        return NotImplementedMulticallable()
 
     def stream_stream(self, path, request_serializer, response_deserializer):
-        raise NotImplementedError()
+        return NotImplementedMulticallable()
 
 
 class Multicallable:
@@ -55,6 +55,16 @@ class Multicallable:
 
     def future(self, request):
         raise NotImplementedError()
+
+
+class NotImplementedMulticallable(Multicallable):
+    def __init__(self):
+        pass
+
+    def __call__(self, request, timeout=None):
+        def nope(*args, **kwargs):
+            raise NotImplementedError()
+        return nope
 
 
 class UnaryUnaryMulticallable(Multicallable):

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -64,6 +64,7 @@ class NotImplementedMulticallable(Multicallable):
     def __call__(self, request, timeout=None):
         def nope(*args, **kwargs):
             raise NotImplementedError()
+
         return nope
 
 

--- a/sonora/context.py
+++ b/sonora/context.py
@@ -40,7 +40,7 @@ class gRPCContext(grpc.ServicerContext):
 
     def time_remaining(self):
         if self._deadline is not None:
-            return max(time.monotonic() - self._deadline, 0)
+            return max(self._deadline - time.monotonic(), 0)
         else:
             return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,25 @@ def _asgi_helloworld_server(lock, port):
     )
 
 
-def _asgi_benchmark_server(lock, port):
+def _asgi_daphne_benchmark_server(lock, port):
     lock.release()
     os.execvp(
         "daphne",
         ["daphne", f"-p{port}", "-v0", "tests.conftest:asgi_benchmark_application"],
+    )
+
+
+def _asgi_uvicorn_benchmark_server(lock, port):
+    lock.release()
+    os.execvp(
+        "uvicorn",
+        [
+            "uvicorn",
+            "--port",
+            f"{port}",
+            "--no-access-log",
+            "tests.conftest:asgi_benchmark_application",
+        ],
     )
 
 
@@ -202,7 +216,9 @@ def _server_fixture(server):
 asgi_grpc_server = pytest.fixture(_server_fixture(_asgi_helloworld_server))
 wsgi_grpc_server = pytest.fixture(_server_fixture(_wsgi_helloworld_server))
 
-asgi_benchmark_grpc_server = pytest.fixture(_server_fixture(_asgi_benchmark_server))
+asgi_benchmark_grpc_server = pytest.fixture(
+    _server_fixture(_asgi_uvicorn_benchmark_server)
+)
 grpcio_benchmark_grpc_server = pytest.fixture(_server_fixture(_grpcio_benchmark_server))
 
 asgi_helloworld_application = _asgi_helloworld_application()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ def _asgi_helloworld_server(lock, port):
 def _asgi_benchmark_server(lock, port):
     lock.release()
     os.execvp(
-        "daphne", ["daphne", f"-p{port}", "-v0", "tests.conftest:asgi_benchmark_application"],
+        "daphne",
+        ["daphne", f"-p{port}", "-v0", "tests.conftest:asgi_benchmark_application"],
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,6 +200,7 @@ def _server_fixture(server):
 
 
 asgi_grpc_server = pytest.fixture(_server_fixture(_asgi_helloworld_server))
+wsgi_grpc_server = pytest.fixture(_server_fixture(_wsgi_helloworld_server))
 
 asgi_benchmark_grpc_server = pytest.fixture(_server_fixture(_asgi_benchmark_server))
 grpcio_benchmark_grpc_server = pytest.fixture(_server_fixture(_grpcio_benchmark_server))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,6 @@ def _asgi_benchmark_application():
             response.payload.body = request.payload.body
             while 1:
                 yield response
-                await asyncio.sleep(0)
 
         async def StreamingBothWays(self, request, context):
             raise NotImplementedError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ class AsyncGreeter(helloworld_pb2_grpc.GreeterServicer):
     async def Abort(self, request, context):
         context.abort(grpc.StatusCode.ABORTED, "test aborting")
 
-    async def Timeout(self, request, context):
+    async def UnaryTimeout(self, request, context):
         while 1:
             await asyncio.sleep(request.seconds)
 

--- a/tests/protos/tests/benchmark.proto
+++ b/tests/protos/tests/benchmark.proto
@@ -1,0 +1,110 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+package benchmark;
+
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
+// A block of data, to simply increase gRPC message size.
+message Payload {
+  // The type of data in body.
+  PayloadType type = 1;
+  // Primary contents of payload.
+  bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+// Unary request.
+message SimpleRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
+
+  // Desired payload size in the response from the server.
+  int32 response_size = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue response_compressed = 6;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // Whether the server should expect this request to be compressed.
+  BoolValue expect_compressed = 8;
+}
+
+// Unary response, as configured by the request.
+message SimpleResponse {
+  // Payload to increase message size.
+  Payload payload = 1;
+  // The user the request came from, for verifying authentication was
+  // successful when the client expected it.
+  string username = 2;
+  // OAuth scope.
+  string oauth_scope = 3;
+}
+
+service BenchmarkService {
+  // One request followed by one response.
+  // The server returns the client payload as-is.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // Repeated sequence of one request followed by one response.
+  // Should be called streaming ping-pong
+  // The server returns the client payload as-is on each response
+  rpc StreamingCall(stream SimpleRequest) returns (stream SimpleResponse);
+
+  // Single-sided unbounded streaming from client to server
+  // The server returns the client payload as-is once the client does WritesDone
+  rpc StreamingFromClient(stream SimpleRequest) returns (SimpleResponse);
+
+  // Single-sided unbounded streaming from server to client
+  // The server repeatedly returns the client payload as-is
+  rpc StreamingFromServer(SimpleRequest) returns (stream SimpleResponse);
+
+  // Two-sided unbounded streaming between server to client
+  // Both sides send the content of their own choice to the other
+  rpc StreamingBothWays(stream SimpleRequest) returns (stream SimpleResponse);
+}

--- a/tests/protos/tests/helloworld.proto
+++ b/tests/protos/tests/helloworld.proto
@@ -13,6 +13,10 @@ service Greeter {
   rpc SayHelloSlowly (HelloRequest) returns (stream HelloReply) {}
 
   rpc Abort(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  rpc UnaryTimeout(TimeoutRequest) returns (google.protobuf.Empty) {}
+
+  rpc StreamTimeout(TimeoutRequest) returns (stream google.protobuf.Empty) {}
 }
 
 // The request message containing the user's name.
@@ -23,4 +27,8 @@ message HelloRequest {
 // The response message containing the greetings
 message HelloReply {
   string message = 1;
+}
+
+message TimeoutRequest {
+  float seconds = 1;
 }

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -6,9 +6,9 @@ from tests import helloworld_pb2, helloworld_pb2_grpc
 
 
 @pytest.mark.asyncio
-async def test_helloworld_sayhelloslowly_with(asgi_grpc_server):
+async def test_helloworld_sayhelloslowly_with(asgi_greeter_server):
     async with sonora.aio.insecure_web_channel(
-        f"http://localhost:{asgi_grpc_server}"
+        f"http://localhost:{asgi_greeter_server}"
     ) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
 
@@ -30,9 +30,9 @@ async def test_helloworld_sayhelloslowly_with(asgi_grpc_server):
 
 
 @pytest.mark.asyncio
-async def test_helloworld_sayhelloslowly_with_timeout(asgi_grpc_server):
+async def test_helloworld_sayhelloslowly_with_timeout(asgi_greeter_server):
     async with sonora.aio.insecure_web_channel(
-        f"http://localhost:{asgi_grpc_server}"
+        f"http://localhost:{asgi_greeter_server}"
     ) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
 
@@ -50,9 +50,9 @@ async def test_helloworld_sayhelloslowly_with_timeout(asgi_grpc_server):
 
 
 @pytest.mark.asyncio
-async def test_helloworld_sayhello_timeout_async(asgi_grpc_server):
+async def test_helloworld_sayhello_timeout_async(asgi_greeter_server):
     async with sonora.aio.insecure_web_channel(
-        f"http://localhost:{asgi_grpc_server}"
+        f"http://localhost:{asgi_greeter_server}"
     ) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
 

--- a/tests/test_asgi_performance.py
+++ b/tests/test_asgi_performance.py
@@ -24,7 +24,9 @@ def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size)
 
 
 @pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
-def test_asgi_streamingfromserver(asgi_benchmark_grpc_server, event_loop, benchmark, size):
+def test_asgi_streamingfromserver(
+    asgi_benchmark_grpc_server, event_loop, benchmark, size
+):
 
     request_count = 10
     chunk_count = 100
@@ -47,7 +49,7 @@ def test_asgi_streamingfromserver(asgi_benchmark_grpc_server, event_loop, benchm
                     n += 1
                     if n >= chunk_count:
                         break
-                
+
                 assert n == chunk_count
 
             assert recv_bytes == size * request_count * chunk_count

--- a/tests/test_asgi_performance.py
+++ b/tests/test_asgi_performance.py
@@ -4,7 +4,7 @@ import sonora.aio
 from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
-@pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
 def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size):
     async def run():
         async with sonora.aio.insecure_web_channel(
@@ -23,7 +23,7 @@ def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size)
     benchmark(perf)
 
 
-@pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
 def test_asgi_streamingfromserver(
     asgi_benchmark_grpc_server, event_loop, benchmark, size
 ):

--- a/tests/test_asgi_performance.py
+++ b/tests/test_asgi_performance.py
@@ -4,7 +4,7 @@ import sonora.aio
 from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
-@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
 def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size):
     async def run():
         async with sonora.aio.insecure_web_channel(
@@ -15,7 +15,8 @@ def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size)
             request = benchmark_pb2.SimpleRequest(response_size=size)
 
             for _ in range(1000):
-                _ = await stub.UnaryCall(request)
+                message = await stub.UnaryCall(request)
+                assert len(message.payload.body) == size
 
     def perf():
         event_loop.run_until_complete(run())
@@ -23,7 +24,7 @@ def test_asgi_unarycall(asgi_benchmark_grpc_server, benchmark, event_loop, size)
     benchmark(perf)
 
 
-@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
 def test_asgi_streamingfromserver(
     asgi_benchmark_grpc_server, event_loop, benchmark, size
 ):

--- a/tests/test_grpcio_performance.py
+++ b/tests/test_grpcio_performance.py
@@ -6,49 +6,39 @@ from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
 @pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
-def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
+def test_grpcio_unarycall(grpcio_benchmark, benchmark, size):
     def perf():
-        with grpc.insecure_channel(
-            f"localhost:{grpcio_benchmark_grpc_server}"
-        ) as channel:
-            stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
+        request = benchmark_pb2.SimpleRequest(response_size=size)
 
-            request = benchmark_pb2.SimpleRequest(response_size=size)
-
-            for _ in range(1000):
-                message = stub.UnaryCall(request)
-                assert len(message.payload.body) == size
+        for _ in range(1000):
+            message = grpcio_benchmark.UnaryCall(request)
+            assert len(message.payload.body) == size
 
     benchmark(perf)
 
 
 @pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
-def test_grpcio_streamingfromserver(grpcio_benchmark_grpc_server, benchmark, size):
+def test_grpcio_streamingfromserver(grpcio_benchmark, benchmark, size):
 
     request_count = 10
     chunk_count = 100
 
     def perf():
-        with grpc.insecure_channel(
-            f"localhost:{grpcio_benchmark_grpc_server}"
-        ) as channel:
-            stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
+        request = benchmark_pb2.SimpleRequest(response_size=size)
+        request.payload.body = b"\0" * size
 
-            request = benchmark_pb2.SimpleRequest(response_size=size)
-            request.payload.body = b"\0" * size
+        recv_bytes = 0
 
-            recv_bytes = 0
+        for _ in range(request_count):
+            n = 0
+            for message in grpcio_benchmark.StreamingFromServer(request):
+                recv_bytes += len(message.payload.body)
+                n += 1
+                if n >= chunk_count:
+                    break
 
-            for _ in range(request_count):
-                n = 0
-                for message in stub.StreamingFromServer(request):
-                    recv_bytes += len(message.payload.body)
-                    n += 1
-                    if n >= chunk_count:
-                        break
+            assert n == chunk_count
 
-                assert n == chunk_count
-
-            assert recv_bytes == size * request_count * chunk_count
+        assert recv_bytes == size * request_count * chunk_count
 
     benchmark(perf)

--- a/tests/test_grpcio_performance.py
+++ b/tests/test_grpcio_performance.py
@@ -5,7 +5,7 @@ import grpc
 from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
-@pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
 def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
     def perf():
         with grpc.insecure_channel(
@@ -21,7 +21,7 @@ def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
     benchmark(perf)
 
 
-@pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
 def test_grpcio_streamingfromserver(grpcio_benchmark_grpc_server, benchmark, size):
 
     request_count = 10

--- a/tests/test_grpcio_performance.py
+++ b/tests/test_grpcio_performance.py
@@ -5,7 +5,7 @@ import grpc
 from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
-@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
 def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
     def perf():
         with grpc.insecure_channel(
@@ -16,12 +16,13 @@ def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
             request = benchmark_pb2.SimpleRequest(response_size=size)
 
             for _ in range(1000):
-                _ = stub.UnaryCall(request)
+                message = stub.UnaryCall(request)
+                assert len(message.payload.body) == size
 
     benchmark(perf)
 
 
-@pytest.mark.parametrize("size", [1, 100, 1000, 10000, 100000])
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
 def test_grpcio_streamingfromserver(grpcio_benchmark_grpc_server, benchmark, size):
 
     request_count = 10

--- a/tests/test_grpcio_performance.py
+++ b/tests/test_grpcio_performance.py
@@ -8,7 +8,9 @@ from tests import benchmark_pb2, benchmark_pb2_grpc
 @pytest.mark.parametrize("size", [0, 100, 1000, 10000, 100000])
 def test_grpcio_unarycall(grpcio_benchmark_grpc_server, benchmark, size):
     def perf():
-        with grpc.insecure_channel(f'localhost:{grpcio_benchmark_grpc_server}') as channel:
+        with grpc.insecure_channel(
+            f"localhost:{grpcio_benchmark_grpc_server}"
+        ) as channel:
             stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
 
             request = benchmark_pb2.SimpleRequest(response_size=size)
@@ -26,7 +28,9 @@ def test_grpcio_streamingfromserver(grpcio_benchmark_grpc_server, benchmark, siz
     chunk_count = 100
 
     def perf():
-        with grpc.insecure_channel(f'localhost:{grpcio_benchmark_grpc_server}') as channel:
+        with grpc.insecure_channel(
+            f"localhost:{grpcio_benchmark_grpc_server}"
+        ) as channel:
             stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
 
             request = benchmark_pb2.SimpleRequest(response_size=size)
@@ -41,10 +45,9 @@ def test_grpcio_streamingfromserver(grpcio_benchmark_grpc_server, benchmark, siz
                     n += 1
                     if n >= chunk_count:
                         break
-                
-                assert n == chunk_count
-            
-            assert recv_bytes == size * request_count * chunk_count
 
+                assert n == chunk_count
+
+            assert recv_bytes == size * request_count * chunk_count
 
     benchmark(perf)

--- a/tests/test_wsgi_performance.py
+++ b/tests/test_wsgi_performance.py
@@ -1,0 +1,55 @@
+import pytest
+
+import sonora.client
+from tests import benchmark_pb2, benchmark_pb2_grpc
+
+
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
+def test_wsgi_unarycall(wsgi_benchmark_grpc_server, benchmark, size):
+    def perf():
+        with sonora.client.insecure_web_channel(
+            f"http://localhost:{wsgi_benchmark_grpc_server}"
+        ) as channel:
+            stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
+
+            request = benchmark_pb2.SimpleRequest(response_size=size)
+
+            for _ in range(1000):
+                message = stub.UnaryCall(request)
+                assert len(message.payload.body) == size
+
+    benchmark(perf)
+
+
+@pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
+def test_wsgi_streamingfromserver(
+    wsgi_benchmark_grpc_server, benchmark, size
+):
+
+    request_count = 10
+    chunk_count = 100
+
+    def perf():
+        with sonora.client.insecure_web_channel(
+            f"http://localhost:{wsgi_benchmark_grpc_server}"
+        ) as channel:
+            stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
+
+            request = benchmark_pb2.SimpleRequest(response_size=size)
+            request.payload.body = b"\0" * size
+
+            recv_bytes = 0
+
+            for _ in range(request_count):
+                n = 0
+                for message in stub.StreamingFromServer(request):
+                    recv_bytes += len(message.payload.body)
+                    n += 1
+                    if n >= chunk_count:
+                        break
+
+                assert n == chunk_count
+
+            assert recv_bytes == size * request_count * chunk_count
+
+    benchmark(perf)

--- a/tests/test_wsgi_performance.py
+++ b/tests/test_wsgi_performance.py
@@ -22,9 +22,7 @@ def test_wsgi_unarycall(wsgi_benchmark_grpc_server, benchmark, size):
 
 
 @pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
-def test_wsgi_streamingfromserver(
-    wsgi_benchmark_grpc_server, benchmark, size
-):
+def test_wsgi_streamingfromserver(wsgi_benchmark_grpc_server, benchmark, size):
 
     request_count = 10
     chunk_count = 100

--- a/tests/test_wsgi_performance.py
+++ b/tests/test_wsgi_performance.py
@@ -5,10 +5,10 @@ from tests import benchmark_pb2, benchmark_pb2_grpc
 
 
 @pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
-def test_wsgi_unarycall(wsgi_benchmark_grpc_server, benchmark, size):
+def test_wsgi_unarycall(wsgi_benchmark_server, benchmark, size):
     def perf():
         with sonora.client.insecure_web_channel(
-            f"http://localhost:{wsgi_benchmark_grpc_server}"
+            f"http://localhost:{wsgi_benchmark_server}"
         ) as channel:
             stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
 
@@ -22,14 +22,14 @@ def test_wsgi_unarycall(wsgi_benchmark_grpc_server, benchmark, size):
 
 
 @pytest.mark.parametrize("size", [1, 100, 10000, 1000000])
-def test_wsgi_streamingfromserver(wsgi_benchmark_grpc_server, benchmark, size):
+def test_wsgi_streamingfromserver(wsgi_benchmark_server, benchmark, size):
 
     request_count = 10
     chunk_count = 100
 
     def perf():
         with sonora.client.insecure_web_channel(
-            f"http://localhost:{wsgi_benchmark_grpc_server}"
+            f"http://localhost:{wsgi_benchmark_server}"
         ) as channel:
             stub = benchmark_pb2_grpc.BenchmarkServiceStub(channel)
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ commands =
         --proto_path=tests/protos/ \
         --python_out=. \
         --grpc_python_out=. \
-        tests/protos/tests/helloworld.proto
+        tests/protos/tests/helloworld.proto \
+        tests/protos/tests/benchmark.proto
     {envpython} -m pytest {posargs}
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
         --grpc_python_out=. \
         tests/protos/tests/helloworld.proto \
         tests/protos/tests/benchmark.proto
-    {envpython} -m pytest {posargs}
+    {envpython} -m pytest --benchmark-sort=name {posargs}
 
 [testenv:black]
 deps=black


### PR DESCRIPTION
As you would expect performance is pretty dependent on the ASGI server you use. 

Performance is tolerable but seems like there's something odd going on. e.g. Why is WSGI streaming so incredibly fast but Unary calls are terrible?

While writing this I discovered that currently it doesn't detect disconnecting clients well enough which results in e.g. infinitely long streams never getting interrupted. All the sent data just gets backed up in asyncio. Solving this required some ugly ascynio.wait usage to check both the send and receive coroutines at once.

I think this causes some flow control issues that are holding the ASGI speed back.

This needs some refactoring now that we have multiple different servers in the test suite.

- [x] Refactor server fixtures to be more composable.
- [x] Use uvicorn instead of Daphne.
- [x] Use bjoern for wsgi tests.
- [x] Add WSGI benchmarks