### PR TITLE
Make sure we release aiohttp connections even when the response is infinite

### DIFF
--- a/sonora/aio.py
+++ b/sonora/aio.py
@@ -17,6 +17,7 @@ class WebChannel:
             url = f"http://{url}"
 
         self._url = url
+
         self._session = aiohttp.ClientSession()
 
     async def __aenter__(self):
@@ -79,6 +80,10 @@ class Call(sonora.client.Call):
         if self._response:
             self._response.release()
 
+    def __del__(self):
+        if self._response:
+            self._response.release()
+
     async def _get_response(self):
         if self._response is None:
             timeout = aiohttp.ClientTimeout(total=self._timeout)
@@ -137,6 +142,7 @@ class UnaryStreamCall(Call):
     @Call._raise_timeout(asyncio.TimeoutError)
     async def __aiter__(self):
         response = await self._get_response()
+
         async for trailers, _, message in protocol.unwrap_message_stream_async(
             response.content
         ):

--- a/tests/test_asgi_helloworld.py
+++ b/tests/test_asgi_helloworld.py
@@ -44,6 +44,20 @@ async def test_helloworld_sayhelloslowly(asgi_greeter):
 
 
 @pytest.mark.asyncio
+async def test_helloworld_sayhelloslowly_read(asgi_greeter):
+    for name in ("you", "world"):
+        request = helloworld_pb2.HelloRequest(name=name)
+        message = ""
+        with asgi_greeter.SayHelloSlowly(request) as stream:
+            chunk = await stream.read()
+            while chunk:
+                message += chunk.message
+                chunk = await stream.read()
+        assert message != name
+        assert name in message
+
+
+@pytest.mark.asyncio
 async def test_helloworld_abort(asgi_greeter):
     with pytest.raises(grpc.RpcError) as exc:
         await asgi_greeter.Abort(Empty())


### PR DESCRIPTION
Previously we'd leak connections if the streaming response was infinite and the client wasn't being used in a context manager. Now we explicitly release the connection when the Call is GCd.

Also refactored the benchmarks for slightly lower overhead.