### PR TITLE
Set content-length headers for unary calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ EMAIL = "alexs@prol.etari.at"
 AUTHOR = "Alex Stapleton"
 REQUIRES_PYTHON = ">=3.7.0"
 
-REQUIRED = ["grpcio", "requests", "aiohttp", "async-timeout"]
+REQUIRED = ["grpcio", "urllib3", "aiohttp", "async-timeout"]
 
 TESTS_REQUIRED = [
     "grpcio-tools",
@@ -22,7 +22,6 @@ TESTS_REQUIRED = [
     "pytest-mockservers",
     "pytest-asyncio",
     "pytest-benchmark",
-    "requests",
     "bjoern",
     "uvicorn",
     "aiohttp[speedups]",

--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -178,6 +178,8 @@ class grpcASGI(grpc.Server):
                     False, False, rpc_method.response_serializer(message)
                 )
 
+                headers.append((b"content-length", str(len(body)).encode()))
+
                 await send(
                     {
                         "type": "http.response.start",

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -208,7 +208,9 @@ class UnaryStreamCall(Call):
                 else:
                     yield self._deserializer(message)
 
-            protocol.raise_for_status(self._response.headers, message if trailers else None)
+            protocol.raise_for_status(
+                self._response.headers, message if trailers else None
+            )
 
         finally:
             self._response.close()

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -210,9 +210,7 @@ class UnaryStreamCall(Call):
 
         self._response.release_conn()
 
-        protocol.raise_for_status(
-            self._response.headers, message if trailers else None
-        )
+        protocol.raise_for_status(self._response.headers, message if trailers else None)
 
     def __del__(self):
         if self._response and self._response.connection:

--- a/sonora/client.py
+++ b/sonora/client.py
@@ -1,9 +1,11 @@
 import functools
 import inspect
+import io
 from urllib.parse import urljoin
 
 import grpc
-import requests
+import urllib3
+import urllib3.exceptions
 
 from sonora import protocol
 
@@ -18,13 +20,13 @@ class WebChannel:
             url = f"http://{url}"
 
         self._url = url
-        self._session = requests.Session()
+        self._session = urllib3.PoolManager()
 
     def __enter__(self):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        self._session.close()
+        self._session.clear()
 
     def unary_unary(self, path, request_serializer, response_deserializer):
         return UnaryUnaryMulticallable(
@@ -168,38 +170,45 @@ class Call:
 
 
 class UnaryUnaryCall(Call):
-    @Call._raise_timeout(requests.exceptions.Timeout)
+    @Call._raise_timeout(urllib3.exceptions.TimeoutError)
     def __call__(self):
-        with self._session.post(
+        self._response = self._session.request(
+            "POST",
             self._url,
-            data=protocol.wrap_message(False, False, self._serializer(self._request)),
+            body=protocol.wrap_message(False, False, self._serializer(self._request)),
             headers=self._metadata,
             timeout=self._timeout,
-        ) as self._response:
-            protocol.raise_for_status(self._response.headers)
-            trailers, _, message = protocol.unrwap_message(self._response.content)
-            assert not trailers
-            return self._deserializer(message)
+        )
+
+        protocol.raise_for_status(self._response.headers)
+        _, _, message = protocol.unrwap_message(self._response.data)
+
+        return self._deserializer(message)
 
 
 class UnaryStreamCall(Call):
-    @Call._raise_timeout(requests.exceptions.Timeout)
+    @Call._raise_timeout(urllib3.exceptions.TimeoutError)
     def __iter__(self):
-        with self._session.post(
+        self._response = self._session.request(
+            "POST",
             self._url,
-            data=protocol.wrap_message(False, False, self._serializer(self._request)),
+            body=protocol.wrap_message(False, False, self._serializer(self._request)),
             headers=self._metadata,
             timeout=self._timeout,
-            stream=True,
-        ) as self._response:
-            for trailers, _, message in protocol.unwrap_message_stream(
-                self._response.raw
-            ):
+            preload_content=False,
+        )
+        self._response.auto_close = False
+
+        try:
+            stream = io.BufferedReader(self._response, buffer_size=16384)
+
+            for trailers, _, message in protocol.unwrap_message_stream(stream):
                 if trailers:
                     break
                 else:
                     yield self._deserializer(message)
 
-            protocol.raise_for_status(
-                self._response.headers, message if trailers else None
-            )
+            protocol.raise_for_status(self._response.headers, message if trailers else None)
+
+        finally:
+            self._response.close()

--- a/tests/test_asgi_performance.py
+++ b/tests/test_asgi_performance.py
@@ -33,11 +33,12 @@ def test_asgi_streamingfromserver(asgi_benchmark, event_loop, benchmark, size):
         recv_bytes = 0
         n = 0
 
-        async for message in asgi_benchmark.StreamingFromServer(request):
-            recv_bytes += len(message.payload.body)
-            n += 1
-            if n >= chunk_count:
-                break
+        with asgi_benchmark.StreamingFromServer(request) as stream:
+            async for message in stream:
+                recv_bytes += len(message.payload.body)
+                n += 1
+                if n >= chunk_count:
+                    break
 
         assert recv_bytes == size * chunk_count
 


### PR DESCRIPTION
And also replace requests with raw urllib3.

This massively improves unaryunary performance, especially for the wsgi tests.