### PR TITLE
Update the statement about gRPC Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Sonora is a Python-first implementation of gRPC-Web built on top of standard Pyt
 
 Regular gRPC has a lot going for it but is awkward to use in some environments. gRPC-Web makes it easy to get gRPC working in
 environments that need HTTP/1.1 but the Google gRPC and gRPC-Web implementations don't like to coexist with your normal Python
-frameworks like Django or Flask. Unlike [grpc/grpc](https://github.com/grpc/grpc) Sonora doesn't care what ioloop you use, this
-means you can run it along side any other Python web framework in the same application!
+frameworks like Django or Flask. Sonora doesn't care what ioloop you use, this means you can run it along side any other Python
+web framework in the same application!
 
 This makes it easy to
 


### PR DESCRIPTION
gRPC Python now has a new AsyncIO stack: https://github.com/grpc/grpc/projects/16. Technically, it supports any AsyncIO I/O loop with single or more threads https://github.com/grpc/grpc/pull/22311. So, can we update the README.md to better reflect this fact?

CC @gnossen
