### PR TITLE
Always send grpc-status in trailers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py37,py39,py310,black
+envlist = py37,py39,py310,black,interop
 isolated_build = True
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install
     {envpython} -m grpc_tools.protoc \
@@ -19,3 +19,18 @@ commands =
 deps=black
 basepython=python3
 commands=black --verbose --check --exclude _pb2 sonora/ tests/
+
+
+[testenv:interop-wsgi]
+allowlist_externals=docker
+commands=
+    docker compose up -d wsgi-server
+    docker compose run interop-grpcweb
+    docker compose stop wsgi-server
+
+[testenv:interop-asgi]
+allowlist_externals=docker
+commands=
+    docker compose up -d asgi-server
+    docker compose run interop-grpcweb
+    docker compose stop asgi-server


### PR DESCRIPTION
This makes it so we always send a trailers frame by forcing grpc-status into the trailers even when we have the option of sending it as a header.

Fixes #47 