### PR TITLE
allow url prefix

### DIFF
--- a/sonora/client.py
+++ b/sonora/client.py
@@ -52,7 +52,7 @@ class Multicallable:
 
         self._url = url
         self._path = path
-        self._rpc_url = urljoin(url, path)
+        self._rpc_url = urljoin(url, path[1:])
 
         self._metadata = [
             ("x-user-agent", "grpc-web-python/0.1"),


### PR DESCRIPTION
If we have a base url like `https://example.com/api` and rpc path like `/package.Service/Method`, when urllib wants to join the paths, it will truncate `/api` and returns `https://example.com/package.Service/Method` because rpc path is starting with leading slash. This pull request will cut the first slash from the method path so that library can join them correctly.