### PR TITLE
Fix trailer encoding

### DIFF
--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -210,11 +210,11 @@ class grpcASGI(grpc.Server):
         else:
             message_data = b""
 
-        trailers = [(b"grpc-status", str(context.code.value[0]).encode())]
+        trailers = [("grpc-status", str(context.code.value[0]))]
 
         if context.details:
             trailers.append(
-                (b"grpc-message", quote(context.details.encode("utf8")).encode("ascii"))
+                ("grpc-message", quote(context.details))
             )
 
         if context._trailing_metadata:

--- a/sonora/protocol.py
+++ b/sonora/protocol.py
@@ -121,11 +121,14 @@ b64_unwrap_message_asgi = functools.partial(
 
 
 def pack_trailers(trailers):
-    message = []
+    data = bytearray()
     for k, v in trailers:
         k = k.lower()
-        message.append(f"{k}: {v}\r\n".encode("ascii"))
-    return b"".join(message)
+        data.extend(k.encode('utf8'))
+        data.extend(b': ')
+        data.extend(v.encode('utf8'))
+        data.extend(b'\r\n')
+    return bytes(data)
 
 
 def unpack_trailers(message):

--- a/sonora/wsgi.py
+++ b/sonora/wsgi.py
@@ -180,7 +180,7 @@ class grpcWSGI(grpc.Server):
         trailers = [("grpc-status", str(context.code.value[0]))]
 
         if context.details:
-            trailers.append(("grpc-message", quote(context.details.encode("utf8"))))
+            trailers.append(("grpc-message", quote(context.details)))
 
         if context._trailing_metadata:
             trailers.extend(context._trailing_metadata)


### PR DESCRIPTION
I saw trailers encoded like `b'grpc-status': b'0'` which is happening because strings and bytes were being mixed. Now trailers are always strings and they're encoded in the pack_trailers method