### PR TITLE
Fix a gRPC error

### DIFF
--- a/sonora/asgi.py
+++ b/sonora/asgi.py
@@ -105,7 +105,7 @@ class grpcASGI(grpc.Server):
             raise NotImplementedError
 
         request_proto_iterator = (
-            rpc_method.request_deserializer(message)
+            rpc_method.request_deserializer(bytes(message))
             async for _, _, message in unwrap_message(receive)
         )
 


### PR DESCRIPTION
If you pass a bytearray to the "message"(look at the commit) it will make an error. This will convert it to the correct datatype