### PR TITLE
Handle StopIteration error from issue #60

### DIFF
--- a/sonora/wsgi.py
+++ b/sonora/wsgi.py
@@ -136,15 +136,16 @@ class grpcWSGI(grpc.Server):
     ):
         try:
             first_message = next(resp)
-        except grpc.RpcError:
-            pass
+        except (grpc.RpcError, StopIteration):
+            first_message = None
 
         if context._initial_metadata:
             headers.extend(context._initial_metadata)
 
         start_response("200 OK", headers)
 
-        yield wrap_message(False, False, rpc_method.response_serializer(first_message))
+        if first_message is not None:
+            yield wrap_message(False, False, rpc_method.response_serializer(first_message))
 
         try:
             for message in resp:


### PR DESCRIPTION
As discussed in issue https://github.com/public/sonora/issues/60, `sonora` incorrectly raises an exception when the `grpc` service streams an empty iterable - which is valid.

Here I simply catch the `StopIteration` error, so that an empty stream is processed correctly without raising an error.